### PR TITLE
Resolve #5 - Implement Player Two Paddle

### DIFF
--- a/src/Ball.hx
+++ b/src/Ball.hx
@@ -9,6 +9,7 @@ class Ball extends Object {
 
 	public function new(x:Float, y:Float, size:Int, ?moveRight:Bool = true, ?speed:Float = 1, ?parent:Object) {
 		super(parent);
+		name = 'BALL';
 		this.x = x;
 		this.y = y;
 		this.speed = speed;

--- a/src/Main.hx
+++ b/src/Main.hx
@@ -1,32 +1,21 @@
-import hxd.res.DefaultFont;
-import h2d.Font;
-import h2d.Text;
 import hxd.App;
 
 class Main extends App {
-	var tf:Text;
 	var ball:Ball;
 	var playerOnePaddle:Paddle;
+	var playerTwoPaddle:Paddle;
 
 	override function init() {
-		var font:Font = DefaultFont.get();
-		tf = new Text(font);
-		tf.text = 'Hello, World!';
-		tf.textAlign = Center;
-		tf.x = s2d.width / 2;
-		tf.y = 50;
-
-		s2d.addChild(tf);
-
-		// @todo left and right direction should be based on which player last scored; only pick random direction when score is 0-0.
 		var moveRight:Bool = Math.floor(Math.random() * 2) > 0;
 		ball = new Ball(s2d.width / 2, s2d.height / 2, 10, moveRight, 4, s2d);
-		playerOnePaddle = new Paddle(s2d);
+		playerOnePaddle = new Paddle(Player.Position.ONE, Player.Brain.HUMAN, s2d);
+		playerTwoPaddle = new Paddle(Player.Position.TWO, Player.Brain.CPU, s2d);
 	}
 
 	override function update(dt:Float) {
 		ball.update(dt);
 		playerOnePaddle.update(dt);
+		playerTwoPaddle.update(dt);
 	}
 
 	static function main() {

--- a/src/Paddle.hx
+++ b/src/Paddle.hx
@@ -1,5 +1,7 @@
-import hxd.Key;
+import Player.Position;
+import Player.Brain;
 import h2d.Tile;
+import hxd.Key;
 import h2d.Bitmap;
 import h2d.Object;
 
@@ -9,15 +11,24 @@ class Paddle extends Object {
 	var speed:Float = 6;
 	var bmp:Bitmap;
 	var direction:Int = 0;
+	var playerPosition:Position;
+	var brain:Brain;
+	var ball:Object;
 
-	public function new(?parent:Object) {
+	public function new(playerPosition:Position, brain:Brain, ?parent:Object) {
 		super(parent);
 
-		x = parent.getScene().width - 120;
+		this.playerPosition = playerPosition;
+		this.brain = brain;
+		x = playerPosition == Position.ONE ? parent.getScene().width - 120 : 120;
 		y = parent.getScene().height / 2;
 		rotation = Math.PI / 2;
 
-		CreateGraphic(0x00BFFF, width, height);
+		// @warn This will necessitate that the ball is instantiated BEFORE the paddle. Consider another approach.
+		ball = parent.getScene().getObjectByName('BALL');
+
+		var color:Int = playerPosition == Position.ONE ? 0x00BFFF : 0xFF1493;
+		CreateGraphic(color, width, height);
 	}
 
 	public function update(dt:Float) {
@@ -32,12 +43,34 @@ class Paddle extends Object {
 	private function GetDirection() {
 		var direction = 0;
 
-		if (Key.isDown(Key.UP)) {
-			direction = -1;
+		if (brain == Brain.CPU && ball != null) {
+			var deltaX = Math.abs(ball.x - x);
+			if ((ball.y < y + height / 2 - 15 && ball.y > y - height / 2 + 15) || deltaX > (parent.getScene().width / 2 - 120)) {
+				direction = 0;
+			} else if (ball.y > y) {
+				direction = 1;
+			} else if (ball.y < y) {
+				direction = -1;
+			}
+		} else {
+			switch playerPosition {
+				case Position.TWO:
+					if (Key.isDown(Key.W)) {
+						direction = -1;
+					}
+					if (Key.isDown(Key.S)) {
+						direction = 1;
+					}
+				default:
+					if (Key.isDown(Key.UP)) {
+						direction = -1;
+					}
+					if (Key.isDown(Key.DOWN)) {
+						direction = 1;
+					}
+			}
 		}
-		if (Key.isDown(Key.DOWN)) {
-			direction = 1;
-		}
+
 		return direction;
 	}
 

--- a/src/Player.hx
+++ b/src/Player.hx
@@ -1,0 +1,9 @@
+enum Position {
+	ONE;
+	TWO;
+}
+
+enum Brain {
+	HUMAN;
+	CPU;
+}


### PR DESCRIPTION
Adds a second paddle on the left side of the screen that can be controlled by a player using the A and S keys. The CPU can also control paddles (though it probably needs to be improved since it is pretty choppy at the moment...I'll make another issue for it).